### PR TITLE
Support cloud.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Jetbrains working folder
+.idea/

--- a/Examples/FileExample/FileExample.csproj
+++ b/Examples/FileExample/FileExample.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\..\TileDB.Cloud\TileDB.Cloud.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>

--- a/Examples/FileExample/Program.cs
+++ b/Examples/FileExample/Program.cs
@@ -6,16 +6,19 @@ namespace FileExample
     {
         static void Main(string[] args)
         {
-            Console.WriteLine("Hello World!");
-            TileDB.Cloud.Rest.Client.Configuration cfg = new TileDB.Cloud.Rest.Client.Configuration();
+            var cfg = (new TileDB.Cloud.Config()).GetConfig();
 
-            cfg.BasePath = "https://api.tiledb.com/v1";
-            string rest_token = System.Environment.GetEnvironmentVariable("TILEDB_REST_TOKEN");
-            cfg.AccessToken = rest_token;
-
-             TileDB.Cloud.Rest.Model.User userprofile = TileDB.Cloud.RestUtil.GetUser(cfg);
-             System.Console.WriteLine("{0}", userprofile.ToJson());
-
+            TileDB.Cloud.Rest.Model.User userprofile = TileDB.Cloud.RestUtil.GetUser(cfg);
+            Console.WriteLine("{0}", userprofile.ToJson());
+            
+            var arrayList = TileDB.Cloud.RestUtil.ListArrays(userprofile.Username, cfg: cfg);
+            Console.WriteLine("{0}", arrayList.ToJson());
+            
+            var listPublicArrays = TileDB.Cloud.RestUtil.ListPublicArrays(userprofile.Username, cfg: cfg);
+            Console.WriteLine("{0}", listPublicArrays.ToJson());
+            
+            var listSharedArrays = TileDB.Cloud.RestUtil.ListSharedArrays(userprofile.Username, cfg: cfg);
+            Console.WriteLine("{0}", listSharedArrays.ToJson());
         }
     }
 }

--- a/TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/Model/Organization.cs
+++ b/TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/Model/Organization.cs
@@ -74,7 +74,7 @@ namespace TileDB.Cloud.Rest.Model
             this.Logo = logo;
             this.Description = description;
             this.Users = users;
-            this.AllowedActions = allowedActions;
+            // this.AllowedActions = allowedActions;
             this.NumOfArrays = numOfArrays;
             this.DefaultS3Path = defaultS3Path;
             this.DefaultS3PathCredentialsName = defaultS3PathCredentialsName;
@@ -133,8 +133,8 @@ namespace TileDB.Cloud.Rest.Model
         /// list of actions user is allowed to do on this organization
         /// </summary>
         /// <value>list of actions user is allowed to do on this organization</value>
-        [DataMember(Name="allowed_actions", EmitDefaultValue=false)]
-        public List<NamespaceActions> AllowedActions { get; set; }
+        // [DataMember(Name="allowed_actions", EmitDefaultValue=false)]
+        // public List<NamespaceActions> AllowedActions { get; set; }
 
         /// <summary>
         /// number of registered arrays for this organization
@@ -194,7 +194,7 @@ namespace TileDB.Cloud.Rest.Model
             sb.Append("  Logo: ").Append(Logo).Append("\n");
             sb.Append("  Description: ").Append(Description).Append("\n");
             sb.Append("  Users: ").Append(Users).Append("\n");
-            sb.Append("  AllowedActions: ").Append(AllowedActions).Append("\n");
+            // sb.Append("  AllowedActions: ").Append(AllowedActions).Append("\n");
             sb.Append("  NumOfArrays: ").Append(NumOfArrays).Append("\n");
             sb.Append("  EnabledFeatures: ").Append(EnabledFeatures).Append("\n");
             sb.Append("  UnpaidSubscription: ").Append(UnpaidSubscription).Append("\n");
@@ -276,12 +276,12 @@ namespace TileDB.Cloud.Rest.Model
                     input.Users != null &&
                     this.Users.SequenceEqual(input.Users)
                 ) && 
-                (
-                    this.AllowedActions == input.AllowedActions ||
-                    this.AllowedActions != null &&
-                    input.AllowedActions != null &&
-                    this.AllowedActions.SequenceEqual(input.AllowedActions)
-                ) && 
+                // (
+                //     this.AllowedActions == input.AllowedActions ||
+                //     this.AllowedActions != null &&
+                //     input.AllowedActions != null &&
+                //     this.AllowedActions.SequenceEqual(input.AllowedActions)
+                // ) && 
                 (
                     this.NumOfArrays == input.NumOfArrays ||
                     (this.NumOfArrays != null &&
@@ -340,8 +340,8 @@ namespace TileDB.Cloud.Rest.Model
                     hashCode = hashCode * 59 + this.Description.GetHashCode();
                 if (this.Users != null)
                     hashCode = hashCode * 59 + this.Users.GetHashCode();
-                if (this.AllowedActions != null)
-                    hashCode = hashCode * 59 + this.AllowedActions.GetHashCode();
+                // if (this.AllowedActions != null)
+                //     hashCode = hashCode * 59 + this.AllowedActions.GetHashCode();
                 if (this.NumOfArrays != null)
                     hashCode = hashCode * 59 + this.NumOfArrays.GetHashCode();
                 if (this.EnabledFeatures != null)

--- a/TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/Model/OrganizationUser.cs
+++ b/TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/Model/OrganizationUser.cs
@@ -51,7 +51,7 @@ namespace TileDB.Cloud.Rest.Model
             this.Username = username;
             this.OrganizationName = organizationName;
             this.Role = role;
-            this.AllowedActions = allowedActions;
+            // this.AllowedActions = allowedActions;
         }
 
         /// <summary>
@@ -87,8 +87,8 @@ namespace TileDB.Cloud.Rest.Model
         /// list of actions user is allowed to do on this organization
         /// </summary>
         /// <value>list of actions user is allowed to do on this organization</value>
-        [DataMember(Name="allowed_actions", EmitDefaultValue=false)]
-        public List<NamespaceActions> AllowedActions { get; set; }
+        // [DataMember(Name="allowed_actions", EmitDefaultValue=false)]
+        // public List<NamespaceActions> AllowedActions { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -103,7 +103,7 @@ namespace TileDB.Cloud.Rest.Model
             sb.Append("  Username: ").Append(Username).Append("\n");
             sb.Append("  OrganizationName: ").Append(OrganizationName).Append("\n");
             sb.Append("  Role: ").Append(Role).Append("\n");
-            sb.Append("  AllowedActions: ").Append(AllowedActions).Append("\n");
+            // sb.Append("  AllowedActions: ").Append(AllowedActions).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -137,38 +137,38 @@ namespace TileDB.Cloud.Rest.Model
             if (input == null)
                 return false;
 
-            return 
+            return
                 (
                     this.UserId == input.UserId ||
                     (this.UserId != null &&
-                    this.UserId.Equals(input.UserId))
-                ) && 
+                     this.UserId.Equals(input.UserId))
+                ) &&
                 (
                     this.OrganizationId == input.OrganizationId ||
                     (this.OrganizationId != null &&
-                    this.OrganizationId.Equals(input.OrganizationId))
-                ) && 
+                     this.OrganizationId.Equals(input.OrganizationId))
+                ) &&
                 (
                     this.Username == input.Username ||
                     (this.Username != null &&
-                    this.Username.Equals(input.Username))
-                ) && 
+                     this.Username.Equals(input.Username))
+                ) &&
                 (
                     this.OrganizationName == input.OrganizationName ||
                     (this.OrganizationName != null &&
-                    this.OrganizationName.Equals(input.OrganizationName))
-                ) && 
+                     this.OrganizationName.Equals(input.OrganizationName))
+                ) &&
                 (
                     this.Role == input.Role ||
                     (this.Role != null &&
-                    this.Role.Equals(input.Role))
-                ) && 
-                (
-                    this.AllowedActions == input.AllowedActions ||
-                    this.AllowedActions != null &&
-                    input.AllowedActions != null &&
-                    this.AllowedActions.SequenceEqual(input.AllowedActions)
+                     this.Role.Equals(input.Role))
                 );
+            // (
+            //     this.AllowedActions == input.AllowedActions ||
+            //     this.AllowedActions != null &&
+            //     input.AllowedActions != null &&
+            //     this.AllowedActions.SequenceEqual(input.AllowedActions)
+            // );
         }
 
         /// <summary>
@@ -190,8 +190,8 @@ namespace TileDB.Cloud.Rest.Model
                     hashCode = hashCode * 59 + this.OrganizationName.GetHashCode();
                 if (this.Role != null)
                     hashCode = hashCode * 59 + this.Role.GetHashCode();
-                if (this.AllowedActions != null)
-                    hashCode = hashCode * 59 + this.AllowedActions.GetHashCode();
+                // if (this.AllowedActions != null)
+                //     hashCode = hashCode * 59 + this.AllowedActions.GetHashCode();
                 return hashCode;
             }
         }

--- a/TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/Model/User.cs
+++ b/TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/Model/User.cs
@@ -69,7 +69,7 @@ namespace TileDB.Cloud.Rest.Model
             this.Company = company;
             this.Logo = logo;
             this.Timezone = timezone;
-            this.AllowedActions = allowedActions;
+            // this.AllowedActions = allowedActions;
             this.DefaultS3Path = defaultS3Path;
             this.DefaultS3PathCredentialsName = defaultS3PathCredentialsName;
             this.DefaultNamespaceCharged = defaultNamespaceCharged;
@@ -162,8 +162,8 @@ namespace TileDB.Cloud.Rest.Model
         /// list of actions user is allowed to do on this organization
         /// </summary>
         /// <value>list of actions user is allowed to do on this organization</value>
-        [DataMember(Name="allowed_actions", EmitDefaultValue=false)]
-        public List<NamespaceActions> AllowedActions { get; set; }
+        // [DataMember(Name="allowed_actions", EmitDefaultValue=false)]
+        // public List<NamespaceActions> AllowedActions { get; set; }
 
         /// <summary>
         /// List of extra/optional/beta features to enable for namespace
@@ -220,7 +220,7 @@ namespace TileDB.Cloud.Rest.Model
             sb.Append("  LastActivityDate: ").Append(LastActivityDate).Append("\n");
             sb.Append("  Timezone: ").Append(Timezone).Append("\n");
             sb.Append("  Organizations: ").Append(Organizations).Append("\n");
-            sb.Append("  AllowedActions: ").Append(AllowedActions).Append("\n");
+            // sb.Append("  AllowedActions: ").Append(AllowedActions).Append("\n");
             sb.Append("  EnabledFeatures: ").Append(EnabledFeatures).Append("\n");
             sb.Append("  UnpaidSubscription: ").Append(UnpaidSubscription).Append("\n");
             sb.Append("  DefaultS3Path: ").Append(DefaultS3Path).Append("\n");
@@ -321,12 +321,12 @@ namespace TileDB.Cloud.Rest.Model
                     input.Organizations != null &&
                     this.Organizations.SequenceEqual(input.Organizations)
                 ) && 
-                (
-                    this.AllowedActions == input.AllowedActions ||
-                    this.AllowedActions != null &&
-                    input.AllowedActions != null &&
-                    this.AllowedActions.SequenceEqual(input.AllowedActions)
-                ) && 
+                // (
+                //     this.AllowedActions == input.AllowedActions ||
+                //     this.AllowedActions != null &&
+                //     input.AllowedActions != null &&
+                //     this.AllowedActions.SequenceEqual(input.AllowedActions)
+                // ) && 
                 (
                     this.EnabledFeatures == input.EnabledFeatures ||
                     this.EnabledFeatures != null &&
@@ -388,8 +388,8 @@ namespace TileDB.Cloud.Rest.Model
                     hashCode = hashCode * 59 + this.Timezone.GetHashCode();
                 if (this.Organizations != null)
                     hashCode = hashCode * 59 + this.Organizations.GetHashCode();
-                if (this.AllowedActions != null)
-                    hashCode = hashCode * 59 + this.AllowedActions.GetHashCode();
+                // if (this.AllowedActions != null)
+                //     hashCode = hashCode * 59 + this.AllowedActions.GetHashCode();
                 if (this.EnabledFeatures != null)
                     hashCode = hashCode * 59 + this.EnabledFeatures.GetHashCode();
                 if (this.UnpaidSubscription != null)

--- a/TileDB.Cloud/Client.cs
+++ b/TileDB.Cloud/Client.cs
@@ -1,0 +1,10 @@
+namespace TileDB.Cloud
+{
+    public class Client
+    {
+        // ToDo: Login and save config to cloud.json
+        public static void Login(string? token, string? username, string? password, string? host)
+        {
+        }
+    }
+}

--- a/TileDB.Cloud/Config.cs
+++ b/TileDB.Cloud/Config.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using static System.Environment;
+
+namespace TileDB.Cloud
+{
+    public class RestApiKey
+    {
+        [JsonProperty(PropertyName = "X-TILEDB-REST-API-KEY")]
+        public string Key { get; set; }
+    }
+
+    public class RestConfig
+    {
+        [JsonProperty(PropertyName = "api_key")]
+        public RestApiKey? ApiKey { get; set; }
+
+        [JsonProperty(PropertyName = "host")] public string Host { get; set; }
+
+        [JsonProperty(PropertyName = "verify_ssl")]
+        public string VerifySSL { get; set; }
+
+        [JsonProperty(PropertyName = "username")]
+        public string Username { get; set; }
+
+        [JsonProperty(PropertyName = "password")]
+        public string Password { get; set; }
+    }
+
+    public class Config
+    {
+        const string REST_HOST = "TILEDB_REST_HOST";
+        const string REST_TOKEN = "TILEDB_REST_TOKEN";
+        const string REST_USERNAME = "TILEDB_REST_USERNAME";
+        const string REST_PASSWORD = "TILEDB_REST_PASSWORD";
+
+        public static string DefaultHost = "https://api.tiledb.com";
+
+        public static string DefaultConfigFile =
+            Path.Join(GetFolderPath(SpecialFolder.UserProfile), ".tiledb", "cloud.json");
+
+        private TileDB.Cloud.Rest.Client.Configuration _config;
+
+        public Config()
+        {
+            _config = new TileDB.Cloud.Rest.Client.Configuration();
+            LoadConfiguration();
+        }
+
+        public TileDB.Cloud.Rest.Client.Configuration GetConfig()
+        {
+            return _config;
+        }
+
+        private bool LoadConfiguration(string configFile = "")
+        {
+            if (configFile == string.Empty)
+            {
+                configFile = DefaultConfigFile;
+            }
+
+            string host = GetEnvironmentVariable(REST_HOST);
+            string token = GetEnvironmentVariable(REST_TOKEN);
+            string username = GetEnvironmentVariable(REST_USERNAME);
+            string password = GetEnvironmentVariable(REST_PASSWORD);
+
+            bool VerifySSL = true;
+
+            if (!File.Exists(configFile))
+            {
+                return false;
+            }
+
+            RestConfig restConfig = JsonConvert.DeserializeObject<RestConfig>(File.ReadAllText(configFile));
+
+            if (String.IsNullOrEmpty(username))
+            {
+                if (!String.IsNullOrEmpty(restConfig.Username))
+                {
+                    _config.Username = restConfig.Username;
+                }
+            }
+
+            if (String.IsNullOrEmpty(password))
+            {
+                if (!String.IsNullOrEmpty(restConfig.Password))
+                {
+                    _config.Password = restConfig.Password;
+                }
+            }
+
+            if (String.IsNullOrEmpty(host))
+            {
+                if (!String.IsNullOrEmpty(restConfig.Host))
+                {
+                    host = restConfig.Host;
+                }
+            }
+
+            // if (host.EndsWith("/v1"))
+            // {
+            //     host = host.Remove(host.Length - "/v1".Length);
+            // } else if (host.EndsWith("/v1/"))
+            // {
+            //     host = host.Remove(host.Length - "/v1/".Length);
+            // }
+
+            if (String.IsNullOrEmpty(token))
+            {
+                if (restConfig.ApiKey != null)
+                {
+                    if (!String.IsNullOrEmpty(restConfig.ApiKey.Key))
+                    {
+                        token = restConfig.ApiKey.Key;
+                        _config.ApiKey = new Dictionary<string, string>();
+                        _config.ApiKey.Add("X-TILEDB-REST-API-KEY", token);
+                    }
+                }
+            }
+
+            if (String.IsNullOrEmpty(token) && String.IsNullOrEmpty(username))
+            {
+                return false;
+            }
+
+            if (String.IsNullOrEmpty(host))
+            {
+                _config.BasePath = DefaultHost;
+            }
+            else
+            {
+                _config.BasePath = host;
+            }
+
+            return true;
+        }
+    }
+}

--- a/TileDB.Cloud/RestUtil.cs
+++ b/TileDB.Cloud/RestUtil.cs
@@ -21,22 +21,49 @@ namespace TileDB.Cloud
             return apiInstance.GetArrayMetadata(name_space, array);
         }
 
-        public static Rest.Model.ArrayBrowserData ListArrays(string name_space, string permissions, List<string> tags, List<string> exclude_tags, string search,
-    List<string> file_types, List<string> exclude_file_types, int? page = default(int?), int? per_page = default(int?), Rest.Client.Configuration cfg = null)
+        public static Rest.Model.ArrayBrowserData ListArrays(
+            string name_space, 
+            string permissions = default(string), 
+            List<string> tags = default(List<string>), 
+            List<string> exclude_tags = default(List<string>), 
+            string search = default(string), 
+            List<string> file_types = default(List<string>), 
+            List<string> exclude_file_types = default(List<string>), 
+            int? page = default(int?), 
+            int? per_page = default(int?),
+            Rest.Client.Configuration cfg = null)
         {
             Rest.Api.ArrayApi apiInstance = new Rest.Api.ArrayApi(cfg);
             return apiInstance.ArraysBrowserOwnedGet(page, per_page, search, name_space, null, permissions, tags, exclude_tags, file_types, exclude_file_types, null);
         }
 
-        public static Rest.Model.ArrayBrowserData ListPublicArrays(string name_space, string permissions, List<string> tags, List<string> exclude_tags, string search,
-    List<string> file_types, List<string> exclude_file_types, int? page = default(int?), int? per_page = default(int?), Rest.Client.Configuration cfg = null)
+        public static Rest.Model.ArrayBrowserData ListPublicArrays(
+            string name_space, 
+            string permissions = default(string), 
+            List<string> tags = default(List<string>), 
+            List<string> exclude_tags = default(List<string>), 
+            string search = default(string),
+            List<string> file_types = default(List<string>), 
+            List<string> exclude_file_types = default(List<string>), 
+            int? page = default(int?), 
+            int? per_page = default(int?), 
+            Rest.Client.Configuration cfg = null)
         {
             Rest.Api.ArrayApi apiInstance = new Rest.Api.ArrayApi(cfg);
             return apiInstance.ArraysBrowserPublicGet(page, per_page, search, name_space, null, permissions, tags, exclude_tags, file_types, exclude_file_types, null);
         }
 
-        public static Rest.Model.ArrayBrowserData ListSharedArrays(string name_space, string permissions, List<string> tags, List<string> exclude_tags, string search,
-    List<string> file_types, List<string> exclude_file_types, int? page = default(int?), int? per_page =default(int?), Rest.Client.Configuration cfg = null)
+        public static Rest.Model.ArrayBrowserData ListSharedArrays(
+            string name_space, 
+            string permissions = default(string), 
+            List<string> tags = default(List<string>), 
+            List<string> exclude_tags = default(List<string>), 
+            string search = default(string),
+            List<string> file_types = default(List<string>), 
+            List<string> exclude_file_types = default(List<string>), 
+            int? page = default(int?), 
+            int? per_page =default(int?), 
+            Rest.Client.Configuration cfg = null)
         {
             Rest.Api.ArrayApi apiInstance = new Rest.Api.ArrayApi(cfg);
             return apiInstance.ArraysBrowserSharedGet(page, per_page, search, name_space, null, permissions, tags, exclude_tags, file_types, exclude_file_types, null);

--- a/TileDB.Cloud/TileDB.Cloud.csproj
+++ b/TileDB.Cloud/TileDB.Cloud.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\TileDB.Cloud.Rest\src\TileDB.Cloud.Rest\TileDB.Cloud.Rest.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
Provide the user has `~/tiledb.cloud.json` file setup (using python login), we can support reading from env vars, falling back to reading this file. 

We always respect user env vars

Seems there is an issue with auto generation and  `AllowedActions`, commented out just to prove the user profile can return

Array listing works as expected