### PR TITLE
Enable swagger ui for container

### DIFF
--- a/Examples_Nuget/TestWebApi/Dockerfile
+++ b/Examples_Nuget/TestWebApi/Dockerfile
@@ -1,10 +1,11 @@
 FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
 WORKDIR /app
 EXPOSE 80
-
+ENV ASPNETCORE_ENVIRONMENT=Development
 #---
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+ENV ASPNETCORE_ENVIRONMENT=Development
 WORKDIR /src
 COPY ["TestWebApi.csproj", "."]
 RUN dotnet restore "./TestWebApi.csproj"

--- a/Examples_Nuget/TestWebApi/gitDockerfile
+++ b/Examples_Nuget/TestWebApi/gitDockerfile
@@ -3,8 +3,10 @@
 FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
 WORKDIR /app
 EXPOSE 80
+ENV ASPNETCORE_ENVIRONMENT=Development
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+ENV ASPNETCORE_ENVIRONMENT=Development
 WORKDIR /src
 #COPY ["TestWebApi.csproj", "."]
 #RUN dotnet restore "./TestWebApi.csproj"


### PR DESCRIPTION
By default, swagger ui is only enabled in development environment. This PR add ASPNETCORE_ENVIRONMENT to enable it when it is  deployed into a container. we can access it in browser by http://localhost:5000/swagger