### PR TITLE
Add CI to package and test NuGet releases

### DIFF
--- a/.github/workflows/tiledb-cloud-csharp.yml
+++ b/.github/workflows/tiledb-cloud-csharp.yml
@@ -17,11 +17,13 @@ jobs:
       # Checks out repository
       - uses: actions/checkout@v3
 
+      # Limit GH runner environment to the one version of .NET that we install in next step
       - name: Remove existing .NET versions
         shell: bash
         run: |
           rm -rf $DOTNET_ROOT
 
+      # Following action sets up dotnet and uses the strategy matrix to test on specific versions
       - name: Set up dotnet
         uses: actions/setup-dotnet@v2
         with:
@@ -81,13 +83,13 @@ jobs:
           name: TileDB.Cloud NuGet Package
           path: TileDB.Cloud/out
 
+      # Limit GH runner environment to the one version of .NET that we install in next step
       - name: Remove existing .NET versions
         shell: bash
         run: |
           rm -rf $DOTNET_ROOT
 
-      # Following action sets up dotnet and uses the strategy matrix to test on
-      # specific versions
+      # Following action sets up dotnet and uses the strategy matrix to test on specific versions
       - name: Set up dotnet
         uses: actions/setup-dotnet@v2
         with:

--- a/.github/workflows/tiledb-cloud-csharp.yml
+++ b/.github/workflows/tiledb-cloud-csharp.yml
@@ -1,0 +1,104 @@
+name: TileDB-Cloud-CSharp
+
+on:
+  push:
+    tags: [ '*' ]
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  Pack-TileDB-Cloud:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      # Checks out repository
+      - uses: actions/checkout@v3
+
+      - name: Remove existing .NET versions
+        shell: bash
+        run: |
+          rm -rf $DOTNET_ROOT
+
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+
+      - name: Display .NET versions
+        run: dotnet --info
+
+      - name: Test TileDB.Cloud.Rest
+        shell: bash
+        run: cd TileDB.Cloud.Rest && sh mono_nunit_test.sh
+
+      - name: Pack TileDB.Cloud.Rest
+        shell: bash
+        run: |
+          nuget install TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/packages.config -o TileDB.Cloud.Rest/packages
+          mkdir TileDB.Cloud.Rest/bin
+          find TileDB.Cloud.Rest/packages/ -wholename */net45/*.dll | xargs -I{} cp {} TileDB.Cloud.Rest/bin/ 
+          nuget pack -Build -OutputDirectory TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/out \
+            TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/TileDB.Cloud.Rest.csproj -Properties Configuration=Release
+
+      - name: Pack TileDB.Cloud
+        shell: bash
+        run: |
+          mkdir -p TileDB.Cloud/lib/net5.0 
+          cp TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/bin/Release/TileDB.Cloud.Rest.dll TileDB.Cloud/lib/net5.0/
+          dotnet add TileDB.Cloud/TileDB.Cloud.csproj package TileDB.Cloud.Rest --source \
+            TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/out/ --no-restore
+          dotnet restore TileDB.Cloud/TileDB.Cloud.csproj -s TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/out \
+            -s https://api.nuget.org/v3/index.json --verbosity n
+          nuget pack -Build -OutputDirectory TileDB.Cloud/out TileDB.Cloud/TileDB.Cloud.csproj \
+            -Properties Configuration=Release
+
+      - name: Upload TileDB.Cloud NuGet Package
+        uses: actions/upload-artifact@v3
+        with:
+          name: TileDB.Cloud NuGet Package
+          path: TileDB.Cloud/out/TileDB.Cloud.*.nupkg
+
+  Test-TileDB-Cloud:
+    needs: Pack-TileDB-Cloud
+    strategy:
+      fail-fast: false
+      matrix:
+        # Will be checking following versions
+        dotnet: ['5.0', '6.0']
+        # Repeat this test for each os
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # Checks out repository
+      - uses: actions/checkout@v3
+
+      - name: Download TileDB.Cloud NuGet Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: TileDB.Cloud NuGet Package
+          path: TileDB.Cloud/out
+
+      - name: Remove existing .NET versions
+        shell: bash
+        run: |
+          rm -rf $DOTNET_ROOT
+
+      # Following action sets up dotnet and uses the strategy matrix to test on
+      # specific versions
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+
+      - name: Test TileDB.Cloud NuGet Package
+        shell: bash
+        run: |
+          dotnet add TileDB.Cloud.Test/TileDB.Cloud.Test.csproj package TileDB.Cloud --source TileDB.Cloud/out/ \
+            --no-restore
+          dotnet restore TileDB.Cloud.Test/TileDB.Cloud.Test.csproj --configfile TileDB.Cloud.Test/nuget.config \
+            --verbosity n
+          dotnet test TileDB.Cloud.Test/TileDB.Cloud.Test.csproj --no-restore
+          dotnet remove TileDB.Cloud.Test/TileDB.Cloud.Test.csproj package TileDB.Cloud

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # YAML specification from TileDB-Inc/TileDB-Cloud-API-Spec
 openapi-v1.yaml
+nuget.exe
 
 # User-specific files
 *.rsuser
@@ -33,6 +34,7 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Ll]ogs/
+[Ll]ib/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/

--- a/Examples/FileExample/FileExample.csproj
+++ b/Examples/FileExample/FileExample.csproj
@@ -4,11 +4,6 @@
     <ProjectReference Include="..\..\TileDB.Cloud\TileDB.Cloud.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Polly" Version="7.2.3" />
-  </ItemGroup>
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>

--- a/Examples_Nuget/ArrayShareExample/Program.cs
+++ b/Examples_Nuget/ArrayShareExample/Program.cs
@@ -14,9 +14,9 @@ namespace ArrayShareExample
             var userDetails = TileDB.Cloud.RestUtil.GetUser();
 
             // S3 location of file to convert to TileDB array
-            string fromUriS3 = "s3://iledb-inc-demo-data/files/original/VLDB17_TileDB.pdf";
+            string fromUriS3 = "s3://tiledb-inc-demo-data/files/original/VLDB17_TileDB.pdf";
             // S3 location to store TileDB file array data
-            string toUriS3 = "s3://iledb-inc-demo-data/files/original/VLDB17_TileDB";
+            string toUriS3 = "s3://tiledb-inc-demo-data/files/original/VLDB17_TileDB";
             // Namespace to share array with
             string friendNamespace = "friend-namespace";
             Console.WriteLine($"Converting file '{fromUriS3}' to TileDB array stored at {toUriS3}");

--- a/TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/Properties/AssemblyInfo.cs
+++ b/TileDB.Cloud.Rest/src/TileDB.Cloud.Rest/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.2")]
-[assembly: AssemblyFileVersion("0.2.2")]
+[assembly: AssemblyVersion("0.2.3")]
+[assembly: AssemblyFileVersion("0.2.3")]

--- a/TileDB.Cloud.Test/TileDB.Cloud.Test.csproj
+++ b/TileDB.Cloud.Test/TileDB.Cloud.Test.csproj
@@ -1,47 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <RollForward>Major</RollForward>
     <RootNamespace>TileDB.Cloud.Test</RootNamespace>
     <TargetFrameworks>net5.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-
-
   <ItemGroup>
-    <ProjectReference Include="..\TileDB.Cloud.Rest\src\TileDB.Cloud.Rest\TileDB.Cloud.Rest.csproj" >
-        <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\TileDB.Cloud\TileDB.Cloud.csproj" >
-	  <ReferenceOutputAssembly>true</ReferenceOutputAssembly>
-    </ProjectReference>
-  </ItemGroup>
-
-	<ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="JsonSubTypes" Version="1.6.0" />
-    <PackageReference Include="RestSharp" Version="105.1.0" />
-	<PackageReference Include="Polly" Version="7.2.2" />
-	<PackageReference Include="TileDB.CSharp" Version="2.5.0" />
-  </ItemGroup>  
-
-
- 
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.0" />
   </ItemGroup>
 
- 
-
-   <PropertyGroup>
+  <PropertyGroup>
     <OutputPath>./lib</OutputPath>
   </PropertyGroup>  
 

--- a/TileDB.Cloud.Test/nuget.config
+++ b/TileDB.Cloud.Test/nuget.config
@@ -1,0 +1,6 @@
+<configuration>
+    <packageSources>
+        <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        <add key="Test Source" value="../TileDB.Cloud/out" />
+    </packageSources>
+</configuration>

--- a/TileDB.Cloud/TileDB.Cloud.csproj
+++ b/TileDB.Cloud/TileDB.Cloud.csproj
@@ -1,13 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <Platforms>x64</Platforms>
-	  <PackageId>TileDB.Cloud</PackageId>
-	  <Version>0.2.2</Version>
-	  <Authors>TileDB</Authors>
-	  <Company>TileDB Inc</Company>
+    <PackageId>TileDB.Cloud</PackageId>
+    <Version>0.2.3</Version>
+    <Authors>TileDB</Authors>
+    <Company>TileDB Inc</Company>
     <!-- don't compile everything under path by default -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -24,8 +23,8 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="RestSharp" Version="105.2.3" />
-    <PackageReference Include="TileDB.Cloud.Rest" Version="0.2.2" />
-    <PackageReference Include="TileDB.CSharp" Version="5.0.1" />
+    <PackageReference Include="TileDB.Cloud.Rest" Version="0.2.3" />
+    <PackageReference Include="TileDB.CSharp" Version="5.2.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/TileDB.Cloud/TileDB.Cloud.nuspec
+++ b/TileDB.Cloud/TileDB.Cloud.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>TileDB.Cloud</id>
-    <version>0.2.2</version>
+    <version>0.2.3</version>
     <title>$title$</title>
     <authors>TileDB Inc</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
I made a mistake when packaging 0.2.2 which led to TileDB.Cloud not including a required internal reference to `lib/net5.0/TileDB.Cloud.Rest.dll`. This results in errors when trying to add the 0.2.2 package to a project. 

https://nuget.info/packages/TileDB.Cloud/0.2.2

This 0.2.2 release has been unlisted from NuGet. NuGet doesn't support updating previously released versions, so this PR also bumps version to 0.2.3 to go with the new package.

Added CI to run [generated openapi tests](https://github.com/TileDB-Inc/TileDB-Cloud-CSharp/compare/main...smr/sc-20668/ci-release#diff-f1a396bfbb6aacd9a02045b35ffc1bf49b56b85a89271d6648a36cd0e480ef77R35) and package TileDB.Cloud to upload as artifact. The artifact is then passed to Windows / Mac / Linux runners to test using the `TileDB.Cloud.Test` project using .NET 5.0 and .NET 6.0.

[Here's an example](https://github.com/shaunrd0/TileDB-Cloud-CSharp/actions/runs/2891820263) of a passing CI run on my fork